### PR TITLE
Add permission preventing players from receiving TPA requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ teleport again
 - `/tpacancel [<target>]` - cancels a tpa/tpahere request to `<target>`  
   Permission: `blossom.tpa` (default: true)
 
+A player with the permission `blossom.tpa.disallowed` will not be able to receive tpa requests.
+The player sending the tpa request will receive a warning message, while the player receiving the request will see nothing.
+
 ## Translation keys
 
 Only keys with available arguments are shown, for full list, please see
@@ -49,7 +52,11 @@ Note on terms used here:
 "initiator" - player who initiated the tpa/tpahere request and can /tpacancel it  
 "receiver" - player who's received a tpa/tpahere request and has to /tpaaccept or /tpadeny it
 
+- `blossom.tpa.fail.to-self`: 0 arguments
+- `blossom.tpa.fail.disallowed`: 1 argument - receiver
 - `blossom.tpa.fail.similar`: 1 argument - receiver
+- `blossom.tpa.fail.multiple`: 0 arguments
+- `blossom.tpa.fail.none`: 0 arguments
 - `blossom.tpa.fail.none-from`: 1 argument - initiator
 - `blossom.tpa.fail.cancel.none-to`: 1 argument - receiver
 - `blossom.tpa.to.start.initiator`: 6 arguments - timeout length, initiator, receiver, /tpacancel command, /tpaaccept

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
-mod_version=2.0.3
+mod_version=2.1.0
 maven_group=dev.codedsakura.blossom
 mod_slug=BlossomTPA
 archives_base_name=blossom-tpa
@@ -14,4 +14,4 @@ yarn_mappings=build.2
 loader_version=0.14.7
 
 # Dependencies
-blossomlib_version=2.4.1
+blossomlib_version=2.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ yarn_mappings=build.2
 loader_version=0.14.7
 
 # Dependencies
-blossomlib_version=2.3.0
+blossomlib_version=2.4.1

--- a/src/main/java/dev/codedsakura/blossom/tpa/BlossomTpa.java
+++ b/src/main/java/dev/codedsakura/blossom/tpa/BlossomTpa.java
@@ -68,6 +68,11 @@ public class BlossomTpa implements ModInitializer {
             return Command.SINGLE_SUCCESS;
         }
 
+        if (Permissions.check(receiver, "blossom.tpa.disallowed", false)) {
+            TextUtils.sendErr(ctx, "blossom.tpa.fail.disallowed", receiver);
+            return Command.SINGLE_SUCCESS;
+        }
+
         final TpaRequest tpaRequest = new TpaRequest(initiator, receiver, tpaHere);
         if (activeTpas.stream().anyMatch(tpaRequest::similarTo)) {
             TextUtils.sendErr(ctx, "blossom.tpa.fail.similar", receiver);

--- a/src/main/resources/data/blossom/lang/en_us.json
+++ b/src/main/resources/data/blossom/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "blossom.tpa.fail.to-self": "Cannot teleport to self!",
+  "blossom.tpa.fail.disallowed": "%s can't receive tpas!",
   "blossom.tpa.fail.similar": "A tpa between you and %s already exists!",
   "blossom.tpa.fail.multiple": "You have multiple ongoing tpas!",
   "blossom.tpa.fail.none": "You have no ongoing tpas!",


### PR DESCRIPTION
If a player has the `blossom.tpa.disallowed` permission, they are unable to receive TPA requests. Players who attempt to send them TPA requests are shown a warning message.
(I add this because some of the players on my server are vehemently against any sort of ~~convenience~~ teleportation and would rather not see these requests at all)

Depends on https://github.com/BlossomMods/BlossomLib/pull/4.